### PR TITLE
Fix bot movement and increase player limit

### DIFF
--- a/src/main/java/com/tuempresa/proyecto/demo1/Bot.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/Bot.java
@@ -126,6 +126,17 @@ public class Bot {
         Direccion currentDirection = direccionActual.get();
         Coordenada head = mySnake.cuerpo.get(0);
 
+        // Con una pequeña probabilidad, intentar un giro aleatorio para un comportamiento menos predecible.
+        if (random.nextInt(100) < 10) { // 10% de probabilidad de un giro "aleatorio"
+            Direccion randomTurn = random.nextBoolean() ? getLeftTurn(currentDirection) : getRightTurn(currentDirection);
+            Coordenada nextCoord = getNextCoordenada(head, randomTurn);
+            if (!isCollision(nextCoord, mySnake, snapshot)) {
+                Logger.info("Bot " + botId + " (" + difficulty + ") haciendo un giro aleatorio a " + randomTurn);
+                direccionActual.set(randomTurn);
+                return;
+            }
+        }
+
         // Estrategia de evasión mejorada: probar la dirección actual, luego la derecha, luego la izquierda.
         Direccion[] possibleDirections = {
             currentDirection,


### PR DESCRIPTION
- Modified the bot AI to introduce a degree of randomness, preventing all bots from taking the same actions.
- Increased the number of unique starting positions from 2 to 4, allowing more players to join a game without spawning on top of each other.
- Updated the game reset logic to correctly handle the new starting positions.