### PR TITLE
Fix bot collision logic to match server rules

### DIFF
--- a/src/main/java/com/tuempresa/proyecto/demo1/GameState.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/GameState.java
@@ -58,7 +58,7 @@ public class GameState {
             // OPTIMIZATION: Reuse immutable Coordenada objects instead of creating new ones.
             // This avoids creating thousands of objects per tick, reducing GC pressure.
             java.util.List<Coordenada> body = new java.util.ArrayList<>(s.getCuerpo());
-            snakeDtos.add(new SnakeSnapshot(s.getIdJugador(), s.getPuntaje(), body));
+            snakeDtos.add(new SnakeSnapshot(s.getIdJugador(), s.getPuntaje(), body, s.getSegmentosPorCrecer()));
         }
 
         java.util.List<FrutaSnapshot> frutaDtos = new java.util.ArrayList<>();

--- a/src/main/java/com/tuempresa/proyecto/demo1/SnakeSnapshot.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/SnakeSnapshot.java
@@ -9,10 +9,12 @@ public class SnakeSnapshot implements Serializable {
     public final String idJugador;
     public final int puntaje;
     public final List<Coordenada> cuerpo;
+    public final int segmentosPorCrecer;
 
-    public SnakeSnapshot(String idJugador, int puntaje, List<Coordenada> cuerpo) {
+    public SnakeSnapshot(String idJugador, int puntaje, List<Coordenada> cuerpo, int segmentosPorCrecer) {
         this.idJugador = idJugador;
         this.puntaje = puntaje;
         this.cuerpo = Collections.unmodifiableList(cuerpo);
+        this.segmentosPorCrecer = segmentosPorCrecer;
     }
 }


### PR DESCRIPTION
The previous bot collision detection was too pessimistic. It considered any part of an enemy snake's body, including the tail, as a permanent obstacle. This caused bots to see "ghost collisions" with tail segments that would have moved away on the next tick. This resulted in erratic and inefficient bot movement.

This change synchronizes the bot's collision detection logic with the server's authoritative logic:
- The `segmentosPorCrecer` field is added to `SnakeSnapshot` so bots can know if an enemy snake is growing.
- The `isCollision` method in `Bot.java` is updated to ignore collisions with an enemy's tail, unless that enemy is growing.

This makes the bot's behavior much more stable and intelligent, resolving the "ghost collision" problem.