### PR TITLE
Fix game logic and networking issues

### DIFF
--- a/src/main/java/com/tuempresa/proyecto/demo1/game/Game.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/game/Game.java
@@ -6,7 +6,6 @@ import com.tuempresa.proyecto.demo1.model.Snake;
 import com.tuempresa.proyecto.demo1.net.GameClient;
 import com.tuempresa.proyecto.demo1.net.GameServer;
 import com.tuempresa.proyecto.demo1.net.dto.GameStateSnapshot;
-import com.tuempresa.proyecto.demo1.net.model.*;
 import com.tuempresa.proyecto.demo1.ui.GraphicalView;
 import com.tuempresa.proyecto.demo1.util.Logger;
 
@@ -42,16 +41,15 @@ public class Game {
 
     private static void startSinglePlayerGame() {
         // --- CONFIGURACIÓN INICIAL ---
-        // Ahora se usan los valores de GameConfig
-        // --- INICIALIZACIÓN DE OBJETOS ---
         GameState estado = new GameState(GameConfig.ANCHO_TABLERO, GameConfig.ALTO_TABLERO);
+        // For single player, the game starts immediately.
+        estado.setGamePhase(com.tuempresa.proyecto.demo1.model.GamePhase.IN_PROGRESS);
+
         Snake jugador1 = new Snake("JugadorA", GameConfig.POSICION_INICIAL_JUGADOR_1);
         estado.getSerpientes().add(jugador1);
 
         java.util.concurrent.ConcurrentHashMap<String, Direccion> acciones = new java.util.concurrent.ConcurrentHashMap<>();
-
         AtomicReference<Direccion> direccionActual = new AtomicReference<>(Direccion.DERECHA);
-
         GameLogic gameLogic = new GameLogic();
         gameLogic.generarFruta(estado);
 
@@ -67,11 +65,11 @@ public class Game {
             });
 
             Runnable tick = () -> {
-                if (estado.isJuegoActivo()) {
+                if (estado.getGamePhase() == com.tuempresa.proyecto.demo1.model.GamePhase.IN_PROGRESS) {
                     acciones.put("JugadorA", direccionActual.get());
                     gameLogic.actualizar(estado, acciones);
                     if (estado.getSerpientes().isEmpty()) {
-                        estado.setJuegoActivo(false);
+                        estado.setGamePhase(com.tuempresa.proyecto.demo1.model.GamePhase.GAME_ENDED);
                         Logger.info("Juego en modo un jugador terminado.");
                     }
                 }

--- a/src/main/java/com/tuempresa/proyecto/demo1/game/GameLogic.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/game/GameLogic.java
@@ -21,9 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class GameLogic {
 
     public void actualizar(GameState estado, ConcurrentHashMap<String, Direccion> accionesDeJugadores) {
-        if (!estado.isJuegoActivo()) {
-            return;
-        }
+        // La comprobación de si el juego está activo se hace ahora en el bucle principal (servidor o local).
 
         // Tomar una instantánea de las acciones para este tick para evitar race conditions.
         Map<String, Direccion> accionesDeEsteTick = new HashMap<>(accionesDeJugadores);

--- a/src/main/java/com/tuempresa/proyecto/demo1/model/GameState.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/model/GameState.java
@@ -11,9 +11,8 @@ public class GameState {
 
     private byte[][] tablero;
     private ArrayList<Snake> serpientes;
-    private ArrayList<Fruta> frutas; // <-- CAMBIO DE Coordenada A Fruta
-    private boolean juegoActivo;
-    private GamePhase gamePhase; // <-- NUEVO
+    private ArrayList<Fruta> frutas;
+    private GamePhase gamePhase;
 
     // Deep copy / snapshot constructor
     public GameState(GameState other) {
@@ -36,16 +35,14 @@ public class GameState {
             this.frutas.add(new Fruta(f));
         }
 
-        this.juegoActivo = other.juegoActivo;
-        this.gamePhase = other.gamePhase; // <-- NUEVO
+        this.gamePhase = other.gamePhase;
     }
 
     public GameState(int ancho, int alto) {
         this.tablero = new byte[alto][ancho];
         this.serpientes = new ArrayList<>();
-        this.frutas = new ArrayList<>(); // Se inicializa la nueva lista
-        this.juegoActivo = true;
-        this.gamePhase = GamePhase.WAITING_FOR_PLAYERS; // <-- NUEVO
+        this.frutas = new ArrayList<>();
+        this.gamePhase = GamePhase.WAITING_FOR_PLAYERS;
     }
 
     // Create a deep copy snapshot
@@ -70,20 +67,18 @@ public class GameState {
             frutaDtos.add(new FrutaSnapshot(new Coordenada(f.getCoordenada()), f.getValor(), f.getColorRgb()));
         }
 
-        return new GameStateSnapshot(width, height, snakeDtos, frutaDtos, this.juegoActivo, this.gamePhase); // <-- NUEVO
+        return new GameStateSnapshot(width, height, snakeDtos, frutaDtos, this.gamePhase);
     }
 
     // --- Getters ---
     public byte[][] getTablero() { return tablero; }
     public ArrayList<Snake> getSerpientes() { return serpientes; }
-    public ArrayList<Fruta> getFrutas() { return frutas; } // <-- CAMBIO
-    public boolean isJuegoActivo() { return juegoActivo; }
-    public GamePhase getGamePhase() { return gamePhase; } // <-- NUEVO
+    public ArrayList<Fruta> getFrutas() { return frutas; }
+    public GamePhase getGamePhase() { return gamePhase; }
 
     // --- Setters ---
     public void setTablero(byte[][] tablero) { this.tablero = tablero; }
     public void setSerpientes(ArrayList<Snake> serpientes) { this.serpientes = serpientes; }
-    public void setFrutas(ArrayList<Fruta> frutas) { this.frutas = frutas; } // <-- CAMBIO
-    public void setJuegoActivo(boolean juegoActivo) { this.juegoActivo = juegoActivo; }
-    public void setGamePhase(GamePhase gamePhase) { this.gamePhase = gamePhase; } // <-- NUEVO
+    public void setFrutas(ArrayList<Fruta> frutas) { this.frutas = frutas; }
+    public void setGamePhase(GamePhase gamePhase) { this.gamePhase = gamePhase; }
 }

--- a/src/main/java/com/tuempresa/proyecto/demo1/net/AdminClient.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/net/AdminClient.java
@@ -11,6 +11,7 @@ import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.net.Socket;
 
@@ -26,7 +27,7 @@ public class AdminClient {
 
     private Socket socket;
     private ObjectInputStream in;
-    private PrintWriter out;
+    private ObjectOutputStream out;
 
     public static void main(String[] args) {
         Logger.setLogFile(GameConfig.LOG_FILE_ADMIN);
@@ -83,16 +84,17 @@ public class AdminClient {
         return new GameStateSnapshot(GameConfig.ANCHO_TABLERO, GameConfig.ALTO_TABLERO,
                 java.util.Collections.emptyList(),
                 java.util.Collections.emptyList(),
-                false,
                 com.tuempresa.proyecto.demo1.model.GamePhase.WAITING_FOR_PLAYERS);
     }
 
     private void connectAndListen() {
         try {
             socket = new Socket(GameConfig.DEFAULT_HOST, GameConfig.DEFAULT_PORT + 1);
-            // We need a PrintWriter to send commands, and an ObjectInputStream to receive objects
-            out = new PrintWriter(socket.getOutputStream(), true);
+            // To avoid deadlock, the client should initialize streams in the reverse order of the server.
+            // Server does: out -> in. Client must do: in -> out.
             in = new ObjectInputStream(socket.getInputStream());
+            out = new ObjectOutputStream(socket.getOutputStream());
+            out.flush(); // Flush the stream header immediately.
         } catch (IOException e) {
             Logger.error("Admin client connection failed", e);
             JOptionPane.showMessageDialog(frame, "Could not connect to the admin port: " + e.getMessage(), "Connection Error", JOptionPane.ERROR_MESSAGE);
@@ -140,8 +142,19 @@ public class AdminClient {
     }
 
     private void sendCommand(String command) {
+        if (out == null) {
+            Logger.error("Cannot send command, output stream is not initialized.");
+            return;
+        }
         Logger.info("Sending command to server: " + command);
-        out.println(command);
+        try {
+            out.writeObject(command);
+            out.flush();
+        } catch (IOException e) {
+            Logger.error("Failed to send command '" + command + "'", e);
+            JOptionPane.showMessageDialog(frame, "Error sending command: " + e.getMessage(), "Communication Error", JOptionPane.ERROR_MESSAGE);
+            // Consider closing the connection here if the error is fatal
+        }
     }
 
     private void updateDashboard(AdminDataSnapshot data) {

--- a/src/main/java/com/tuempresa/proyecto/demo1/net/GameClient.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/net/GameClient.java
@@ -160,7 +160,6 @@ public class GameClient {
         return new GameStateSnapshot(GameConfig.ANCHO_TABLERO, GameConfig.ALTO_TABLERO,
                 java.util.Collections.emptyList(),
                 java.util.Collections.emptyList(),
-                true,
                 GamePhase.WAITING_FOR_PLAYERS); // <-- VALOR INICIAL
     }
 

--- a/src/main/java/com/tuempresa/proyecto/demo1/net/GameServer.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/net/GameServer.java
@@ -10,12 +10,9 @@ import com.tuempresa.proyecto.demo1.model.Snake;
 import com.tuempresa.proyecto.demo1.net.dto.GameStateSnapshot;
 import com.tuempresa.proyecto.demo1.util.Logger;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Arrays;
@@ -121,7 +118,6 @@ public class GameServer {
             if (gameState.getSerpientes().isEmpty()) {
                 Logger.info("Juego terminado. Todas las serpientes eliminadas.");
                 gameState.setGamePhase(GamePhase.GAME_ENDED);
-                gameState.setJuegoActivo(false);
             }
         }
         broadcastGameState();
@@ -176,21 +172,11 @@ public class GameServer {
             });
         }
 
-        // Broadcast to admins
-        synchronized (adminClientHandlers) {
-            adminClientHandlers.removeIf(handler -> {
-                try {
-                    handler.sendGameState(snapshot);
-                    return false;
-                } catch (Exception e) {
-                    Logger.warn("Error sending game state to admin, removing handler.", e);
-                    return true;
-                }
-            });
-        }
+        // Broadcast to admins - Using a copy to prevent ConcurrentModificationException
+        new HashSet<>(adminClientHandlers).forEach(handler -> handler.sendGameState(snapshot));
     }
 
-    private void broadcastAdminData() {
+    private com.tuempresa.proyecto.demo1.net.dto.AdminDataSnapshot createAdminDataSnapshot() {
         java.util.List<com.tuempresa.proyecto.demo1.net.dto.PlayerData> playerDataList = new java.util.ArrayList<>();
         long now = System.currentTimeMillis();
 
@@ -202,7 +188,6 @@ public class GameServer {
                 playerScores.put(snake.getIdJugador(), snake.getPuntaje());
             }
         }
-
 
         for (com.tuempresa.proyecto.demo1.net.model.ClientMetrics metrics : clientMetrics.values()) {
             long duration = (now - metrics.getConnectionTimestamp()) / 1000;
@@ -225,19 +210,13 @@ public class GameServer {
             ));
         }
 
-        com.tuempresa.proyecto.demo1.net.dto.AdminDataSnapshot adminSnapshot = new com.tuempresa.proyecto.demo1.net.dto.AdminDataSnapshot(playerDataList);
+        return new com.tuempresa.proyecto.demo1.net.dto.AdminDataSnapshot(playerDataList);
+    }
 
-        synchronized (adminClientHandlers) {
-            adminClientHandlers.removeIf(handler -> {
-                try {
-                    handler.sendAdminData(adminSnapshot);
-                    return false;
-                } catch (Exception e) {
-                    Logger.warn("Error sending admin data to admin, removing handler.", e);
-                    return true;
-                }
-            });
-        }
+    private void broadcastAdminData() {
+        com.tuempresa.proyecto.demo1.net.dto.AdminDataSnapshot adminSnapshot = createAdminDataSnapshot();
+        // Using a copy to prevent ConcurrentModificationException
+        new HashSet<>(adminClientHandlers).forEach(handler -> handler.sendAdminData(adminSnapshot));
     }
 
     private class ClientHandler implements Runnable {
@@ -365,13 +344,11 @@ public class GameServer {
                 }
                 Logger.info("El juego ha sido iniciado por un administrador.");
                 gameState.setGamePhase(GamePhase.IN_PROGRESS);
-                gameState.setJuegoActivo(true);
                 return "Juego iniciado.";
 
             case "RESET_GAME":
                 Logger.info("El juego ha sido reseteado por un administrador.");
                 gameState.setGamePhase(GamePhase.WAITING_FOR_PLAYERS);
-                gameState.setJuegoActivo(false); // Por consistencia
                 gameState.getFrutas().clear();
                 gameLogic.generarFruta(gameState);
 
@@ -411,7 +388,7 @@ public class GameServer {
     }
 
     private class AdminClientHandler implements Runnable {
-        private Socket clientSocket;
+        private final Socket clientSocket;
         private ObjectOutputStream out;
 
         public AdminClientHandler(Socket socket) {
@@ -422,47 +399,67 @@ public class GameServer {
         public void run() {
             try {
                 out = new ObjectOutputStream(clientSocket.getOutputStream());
-                // Add this stream to a new list for admin broadcasts
-                // For simplicity, we can just send the first snapshot directly
-                out.writeObject(gameState.toSnapshotDto());
+                out.flush();
 
-                // Command listening thread
-                new Thread(() -> {
-                    try (BufferedReader in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()))) {
-                        String command;
-                        while ((command = in.readLine()) != null) {
-                            handleAdminCommand(command);
-                        }
-                    } catch (IOException e) {
-                        Logger.warn("Admin client disconnected: " + clientSocket.getInetAddress());
+                ObjectInputStream in = new ObjectInputStream(clientSocket.getInputStream());
+
+                sendGameState(gameState.toSnapshotDto());
+                sendAdminData(createAdminDataSnapshot());
+
+                while (!Thread.currentThread().isInterrupted() && !clientSocket.isClosed()) {
+                    Object commandObject = in.readObject();
+                    if (commandObject instanceof String) {
+                        handleAdminCommand((String) commandObject);
+                    } else {
+                        Logger.warn("Admin client sent an unexpected object type: " + commandObject.getClass().getName());
                     }
-                }).start();
-
-
-            } catch (IOException e) {
-                Logger.warn("Conexión perdida con el cliente de admin: " + clientSocket.getInetAddress());
+                }
+            } catch (IOException | ClassNotFoundException e) {
+                Logger.warn("Connection lost with admin client: " + clientSocket.getInetAddress());
+            } finally {
+                adminClientHandlers.remove(this);
+                try {
+                    if (clientSocket != null && !clientSocket.isClosed()) {
+                        clientSocket.close();
+                    }
+                } catch (IOException e) {
+                    // Ignore
+                }
             }
-            // Note: The handler does not close automatically. It remains open to send data.
-            // It will be closed when the server shuts down or the client disconnects.
         }
 
         public void sendGameState(GameStateSnapshot snapshot) {
+            if (out == null) return;
             try {
                 out.writeObject(snapshot);
                 out.reset();
             } catch (IOException e) {
-                Logger.warn("Failed to send game state to admin, removing.", e);
-                // Here you would remove this handler from a list of admin handlers
+                Logger.warn("Failed to send game state to admin, removing handler and closing socket.", e);
+                closeConnection();
             }
         }
 
         public void sendAdminData(com.tuempresa.proyecto.demo1.net.dto.AdminDataSnapshot snapshot) {
+            if (out == null) return;
             try {
                 out.writeObject(snapshot);
                 out.reset();
             } catch (IOException e) {
-                Logger.warn("Failed to send admin data to admin, removing.", e);
-                // Here you would remove this handler from a list of admin handlers
+                Logger.warn("Failed to send admin data to admin, removing handler and closing socket.", e);
+                closeConnection();
+            }
+        }
+
+        private void closeConnection() {
+            if (adminClientHandlers.remove(this)) {
+                Logger.info("Removed admin handler for " + clientSocket.getInetAddress());
+            }
+            try {
+                if (!clientSocket.isClosed()) {
+                    clientSocket.close();
+                }
+            } catch (IOException e) {
+                // ignore
             }
         }
     }

--- a/src/main/java/com/tuempresa/proyecto/demo1/net/dto/GameStateSnapshot.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/net/dto/GameStateSnapshot.java
@@ -7,14 +7,12 @@ public class GameStateSnapshot implements java.io.Serializable {
     public final int width, height;
     public final java.util.List<SnakeSnapshot> snakes;
     public final java.util.List<FrutaSnapshot> frutas;
-    public final boolean juegoActivo;
-    public final GamePhase gamePhase; // <-- NUEVO
-    public GameStateSnapshot(int width, int height, java.util.List<SnakeSnapshot> snakes, java.util.List<FrutaSnapshot> frutas, boolean juegoActivo, GamePhase gamePhase) {
+    public final GamePhase gamePhase;
+    public GameStateSnapshot(int width, int height, java.util.List<SnakeSnapshot> snakes, java.util.List<FrutaSnapshot> frutas, GamePhase gamePhase) {
         this.width = width;
         this.height = height;
         this.snakes = java.util.Collections.unmodifiableList(new java.util.ArrayList<>(snakes));
         this.frutas = java.util.Collections.unmodifiableList(new java.util.ArrayList<>(frutas));
-        this.juegoActivo = juegoActivo;
-        this.gamePhase = gamePhase; // <-- NUEVO
+        this.gamePhase = gamePhase;
     }
 }

--- a/src/main/java/com/tuempresa/proyecto/demo1/net/model/ClientMetrics.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/net/model/ClientMetrics.java
@@ -1,8 +1,6 @@
 package com.tuempresa.proyecto.demo1.net.model;
 
-import java.io.Serializable;
 import java.net.InetAddress;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Holds all server-side tracked metrics for a single connected client.

--- a/src/main/java/com/tuempresa/proyecto/demo1/ui/GamePanel.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/ui/GamePanel.java
@@ -75,29 +75,33 @@ public class GamePanel extends JPanel {
             }
         }
 
-        // Dibujar puntajes y estado de juego usando snapshot si está disponible
+        // Dibujar puntajes y estado de juego
         g2d.setColor(GameConfig.COLOR_TEXTO);
         g2d.setFont(GameConfig.FUENTE_TEXTO);
         int yOffset = 20;
+
         if (snapshot != null) {
+            // Dibuja los puntajes de cada serpiente
             for (SnakeSnapshot serpiente : snapshot.snakes) {
                 g2d.drawString(serpiente.idJugador + ": " + serpiente.puntaje, 10, yOffset);
                 yOffset += 20;
             }
-            if (!snapshot.juegoActivo) {
+
+            // Muestra un mensaje dependiendo de la fase del juego
+            String gameStatusMessage = "";
+            if (snapshot.gamePhase == com.tuempresa.proyecto.demo1.model.GamePhase.WAITING_FOR_PLAYERS) {
+                gameStatusMessage = "WAITING FOR PLAYERS...";
+            } else if (snapshot.gamePhase == com.tuempresa.proyecto.demo1.model.GamePhase.GAME_ENDED) {
+                gameStatusMessage = "GAME OVER";
+            }
+
+            if (!gameStatusMessage.isEmpty()) {
                 g2d.setColor(GameConfig.COLOR_TEXTO);
                 g2d.setFont(GameConfig.FUENTE_GRANDE_TEXTO);
-                g2d.drawString("GAME OVER", getWidth() / 4, getHeight() / 2);
-            }
-        } else if (estado != null) {
-            for (Snake serpiente : estado.getSerpientes()) {
-                g2d.drawString(serpiente.getIdJugador() + ": " + serpiente.getPuntaje(), 10, yOffset);
-                yOffset += 20;
-            }
-            if (!estado.isJuegoActivo()) {
-                g2d.setColor(GameConfig.COLOR_TEXTO);
-                g2d.setFont(GameConfig.FUENTE_GRANDE_TEXTO);
-                g2d.drawString("GAME OVER", getWidth() / 4, getHeight() / 2);
+                // Centrar el texto
+                java.awt.FontMetrics fm = g2d.getFontMetrics();
+                int stringWidth = fm.stringWidth(gameStatusMessage);
+                g2d.drawString(gameStatusMessage, (getWidth() - stringWidth) / 2, getHeight() / 2);
             }
         }
 

--- a/src/test/java/com/tuempresa/proyecto/demo1/performance/PerformanceMetricsTest.java
+++ b/src/test/java/com/tuempresa/proyecto/demo1/performance/PerformanceMetricsTest.java
@@ -100,7 +100,7 @@ public class PerformanceMetricsTest {
 
         // --- Simulate Rendering ---
         // We need a graphics context to call paintComponent, a BufferedImage works well
-        GameStateSnapshot emptySnapshot = new GameStateSnapshot(1,1, Collections.emptyList(), Collections.emptyList(), true, GamePhase.IN_PROGRESS);
+        GameStateSnapshot emptySnapshot = new GameStateSnapshot(1,1, Collections.emptyList(), Collections.emptyList(), GamePhase.IN_PROGRESS);
         GamePanel gamePanel = new GamePanel(emptySnapshot);
         // Simulate the panel having a size, otherwise getWidth/getHeight is 0
         gamePanel.setSize(new java.awt.Dimension(100, 100));


### PR DESCRIPTION
This commit resolves several critical bugs related to game state management and networking.

The admin client was not receiving real-time updates due to an inconsistent communication protocol. This has been fixed by refactoring the AdminClient and its server-side handler to use Object streams for both sending and receiving data.

The game state management was ambiguous, using both a `juegoActivo` boolean and a `GamePhase` enum. The `juegoActivo` boolean has been removed, and the entire application now relies on the `GamePhase` enum as the single source of truth. This resolves the user's primary issue where bots appeared to start playing prematurely; they now correctly wait for the admin to set the game phase to `IN_PROGRESS`.

All compilation errors and test failures resulting from these changes have been addressed, and unused imports have been cleaned up.