### PR TITLE
Refactor admin client communication and logging

### DIFF
--- a/src/main/java/com/tuempresa/proyecto/demo1/game/GameConfig.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/game/GameConfig.java
@@ -36,7 +36,9 @@ public final class GameConfig {
     public static final boolean LOG_TO_CONSOLE = true;
 
     // Performance Metrics
-    public static final boolean ENABLE_PERFORMANCE_METRICS = true;
+    public static final boolean ENABLE_PERFORMANCE_METRICS = false;
+    // Añadido para controlar el log de la lógica del juego
+    public static final boolean ENABLE_LOGIC_TIME_LOGGING = true;
     public static final long SERVER_TICK_WARNING_THRESHOLD_MS = MILIS_POR_TICK;
 
     // Game Element Codes (from former Constants.java)

--- a/src/main/java/com/tuempresa/proyecto/demo1/net/dto/AdminDataSnapshot.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/net/dto/AdminDataSnapshot.java
@@ -1,18 +1,32 @@
 package com.tuempresa.proyecto.demo1.net.dto;
 
+import com.tuempresa.proyecto.demo1.model.GamePhase;
+
 import java.io.Serializable;
 import java.util.List;
 
 public class AdminDataSnapshot implements Serializable {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L; // Version updated
 
     private final List<PlayerData> players;
+    private final GamePhase gamePhase;
+    private final GameStateSnapshot gameStateSnapshot; // For spectator view
 
-    public AdminDataSnapshot(List<PlayerData> players) {
+    public AdminDataSnapshot(List<PlayerData> players, GamePhase gamePhase, GameStateSnapshot gameStateSnapshot) {
         this.players = players;
+        this.gamePhase = gamePhase;
+        this.gameStateSnapshot = gameStateSnapshot;
     }
 
     public List<PlayerData> getPlayers() {
         return players;
+    }
+
+    public GamePhase getGamePhase() {
+        return gamePhase;
+    }
+
+    public GameStateSnapshot getGameStateSnapshot() {
+        return gameStateSnapshot;
     }
 }

--- a/src/main/java/com/tuempresa/proyecto/demo1/ui/GamePanel.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/ui/GamePanel.java
@@ -24,8 +24,8 @@ public class GamePanel extends JPanel {
 
     public GamePanel(GameStateSnapshot inicial) {
         this.snapshot = inicial;
-        int panelWidth = inicial.width * GameConfig.DEFAULT_TILE_SIZE;
-        int panelHeight = inicial.height * GameConfig.DEFAULT_TILE_SIZE;
+        int panelWidth = (inicial != null ? inicial.width : GameConfig.ANCHO_TABLERO) * GameConfig.DEFAULT_TILE_SIZE;
+        int panelHeight = (inicial != null ? inicial.height : GameConfig.ALTO_TABLERO) * GameConfig.DEFAULT_TILE_SIZE;
         this.setPreferredSize(new Dimension(panelWidth, panelHeight));
         this.setBackground(GameConfig.COLOR_FONDO);
     }


### PR DESCRIPTION
This change addresses performance issues in the Admin Client by optimizing the data sent from the server. Instead of sending two separate objects on each tick, the server now sends a single, consolidated `AdminDataSnapshot` to admin clients. This reduces network overhead and improves performance.

Additionally, this change introduces a new configuration flag, `ENABLE_LOGIC_TIME_LOGGING`, to control the logging of game logic duration. The `ENABLE_PERFORMANCE_METRICS` flag has also been set to `false` by default, as requested.