### PR TITLE
Mejora la descripción de la muerte en los logs

### DIFF
--- a/src/main/java/com/tuempresa/proyecto/demo1/game/GameLogic.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/game/GameLogic.java
@@ -5,72 +5,86 @@ import com.tuempresa.proyecto.demo1.model.Direccion;
 import com.tuempresa.proyecto.demo1.model.Fruta;
 import com.tuempresa.proyecto.demo1.model.GameState;
 import com.tuempresa.proyecto.demo1.model.Snake;
-import com.tuempresa.proyecto.demo1.net.model.*;
+import com.tuempresa.proyecto.demo1.model.CausaMuerte;
 import com.tuempresa.proyecto.demo1.util.Logger;
 
 import java.awt.Color;
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class GameLogic {
 
     public void actualizar(GameState estado, ConcurrentHashMap<String, Direccion> accionesDeJugadores) {
-        // La comprobación de si el juego está activo se hace ahora en el bucle principal (servidor o local).
-
-        // Tomar una instantánea de las acciones para este tick para evitar race conditions.
         Map<String, Direccion> accionesDeEsteTick = new HashMap<>(accionesDeJugadores);
 
-        long startTime = System.nanoTime();
-        // 1. Determinar los próximos movimientos y comprobar colisiones
-        List<Snake> serpientesAeliminar = new ArrayList<>();
-        Set<Coordenada> futurasCabezas = new HashSet<>();
+        // 1. Determinar los próximos movimientos de cada serpiente
+        Map<Snake, Coordenada> futurosMovimientos = new HashMap<>();
         for (Snake s : estado.getSerpientes()) {
-            Coordenada cabezaActual = s.getHead();
             Direccion dir = accionesDeEsteTick.getOrDefault(s.getIdJugador(), Direccion.NINGUNA);
+            Coordenada cabezaActual = s.getHead();
             Coordenada nuevaCabeza;
-
             switch (dir) {
                 case ARRIBA:    nuevaCabeza = new Coordenada(cabezaActual.x, cabezaActual.y - 1); break;
                 case ABAJO:     nuevaCabeza = new Coordenada(cabezaActual.x, cabezaActual.y + 1); break;
                 case IZQUIERDA: nuevaCabeza = new Coordenada(cabezaActual.x - 1, cabezaActual.y); break;
                 case DERECHA:   nuevaCabeza = new Coordenada(cabezaActual.x + 1, cabezaActual.y); break;
-                default: continue; // Si no hay dirección, no hay nada que hacer
+                default:        continue; // No se mueve
             }
+            futurosMovimientos.put(s, nuevaCabeza);
+        }
 
-            if (esColision(estado, s, nuevaCabeza) || !futurasCabezas.add(nuevaCabeza)) {
-                serpientesAeliminar.add(s);
+        // 2. Detectar todas las colisiones
+        Map<Snake, CausaMuerte> serpientesAeliminar = new HashMap<>();
+
+        // 2a. Colisiones con paredes, cuerpo propio o cuerpo de otros
+        for (Map.Entry<Snake, Coordenada> entry : futurosMovimientos.entrySet()) {
+            Snake s = entry.getKey();
+            Coordenada nuevaCabeza = entry.getValue();
+            CausaMuerte causa = determinarCausaColision(estado, s, nuevaCabeza);
+            if (causa != CausaMuerte.NINGUNA) {
+                serpientesAeliminar.put(s, causa);
             }
         }
 
-        // Eliminar las serpientes que colisionaron
-        for (Snake s : serpientesAeliminar) {
-            estado.getSerpientes().remove(s);
-            Logger.info(String.format("Jugador %s eliminado.", s.getIdJugador()));
+        // 2b. Colisiones de cabeza con cabeza
+        Map<Coordenada, List<Snake>> cabezasEnMismaCelda = futurosMovimientos.entrySet().stream()
+                .filter(entry -> !serpientesAeliminar.containsKey(entry.getKey())) // Solo considerar serpientes vivas
+                .collect(Collectors.groupingBy(Map.Entry::getValue,
+                        Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
+
+        for (List<Snake> serpientesEnColision : cabezasEnMismaCelda.values()) {
+            if (serpientesEnColision.size() > 1) {
+                for (Snake s : serpientesEnColision) {
+                    serpientesAeliminar.put(s, CausaMuerte.COLISION_CABEZA);
+                }
+            }
         }
 
-        // 2. Mover las serpientes que sobrevivieron
+        // 3. Eliminar las serpientes que colisionaron
+        if (!serpientesAeliminar.isEmpty()) {
+            for (Map.Entry<Snake, CausaMuerte> entry : serpientesAeliminar.entrySet()) {
+                Snake s = entry.getKey();
+                CausaMuerte causa = entry.getValue();
+                estado.getSerpientes().remove(s);
+                Logger.info(String.format("Jugador %s eliminado: %s.", s.getIdJugador(), getMensajeMuerte(causa)));
+            }
+        }
+
+        // 4. Mover las serpientes que sobrevivieron y gestionar frutas
         for (Snake s : estado.getSerpientes()) {
-             Direccion dir = accionesDeEsteTick.getOrDefault(s.getIdJugador(), Direccion.NINGUNA);
-             Coordenada cabezaActual = s.getHead();
-             Coordenada nuevaCabeza;
-             switch (dir) {
-                case ARRIBA:    nuevaCabeza = new Coordenada(cabezaActual.x, cabezaActual.y - 1); break;
-                case ABAJO:     nuevaCabeza = new Coordenada(cabezaActual.x, cabezaActual.y + 1); break;
-                case IZQUIERDA: nuevaCabeza = new Coordenada(cabezaActual.x - 1, cabezaActual.y); break;
-                case DERECHA:   nuevaCabeza = new Coordenada(cabezaActual.x + 1, cabezaActual.y); break;
-                default: continue;
-            }
+            Coordenada nuevaCabeza = futurosMovimientos.get(s);
+            if (nuevaCabeza == null) continue; // No tenía movimiento
 
             s.getCuerpo().addFirst(nuevaCabeza);
             s.addOcupada(nuevaCabeza);
 
-            // Gestionar crecimiento y colisión con fruta
             boolean comioFruta = false;
             java.util.Iterator<Fruta> fit = estado.getFrutas().iterator();
             while (fit.hasNext()) {
@@ -81,7 +95,7 @@ public class GameLogic {
                     fit.remove();
                     comioFruta = true;
                     Logger.debug(String.format("Jugador %s comió una fruta de valor %d.", s.getIdJugador(), f.getValor()));
-                    break; // Solo se puede comer una fruta por tick
+                    break;
                 }
             }
 
@@ -95,23 +109,35 @@ public class GameLogic {
             }
         }
 
-        long endTime = System.nanoTime();
-        // Logger.debug(String.format("Lógica de juego tomó %.3f ms", (endTime - startTime) / 1_000_000.0));
-
-        // 3. Gestionar aparición de frutas
+        // 5. Gestionar aparición de frutas
         gestionarAparicionDeFrutas(estado);
 
-        // 4. Actualizar el tablero para la vista
+        // 6. Actualizar el tablero para la vista
         actualizarTablero(estado);
+    }
+
+    private String getMensajeMuerte(CausaMuerte causa) {
+        switch (causa) {
+            case COLISION_PARED:
+                return "chocó contra la pared";
+            case COLISION_CUERPO:
+                return "se ha mordido a sí mismo";
+            case COLISION_OTRO_JUGADOR:
+                return "chocó contra otro jugador";
+            case COLISION_CABEZA:
+                return "colisión frontal con otro jugador";
+            default:
+                return "causa desconocida";
+        }
     }
 
     private void gestionarAparicionDeFrutas(GameState estado) {
         if (estado.getSerpientes().isEmpty() && !estado.getFrutas().isEmpty()) {
-            estado.getFrutas().clear(); // Limpiar frutas si no hay jugadores
+            estado.getFrutas().clear();
             return;
         }
         if (estado.getSerpientes().isEmpty()) {
-            return; // No generar frutas si no hay jugadores
+            return;
         }
 
         int numJugadores = estado.getSerpientes().size();
@@ -123,41 +149,32 @@ public class GameLogic {
         }
     }
 
-    private boolean esColision(GameState estado, Snake serpiente, Coordenada nuevaCabeza) {
+    private CausaMuerte determinarCausaColision(GameState estado, Snake serpiente, Coordenada nuevaCabeza) {
         int alto = estado.getTablero().length;
         int ancho = estado.getTablero()[0].length;
 
-        // Colisión con el borde
         if (nuevaCabeza.getX() < 0 || nuevaCabeza.getX() >= ancho || nuevaCabeza.getY() < 0 || nuevaCabeza.getY() >= alto) {
-            return true;
+            return CausaMuerte.COLISION_PARED;
         }
 
-        // Colisión consigo misma
         for (int i = 0; i < serpiente.getCuerpo().size(); i++) {
             if (nuevaCabeza.equals(serpiente.getCuerpo().get(i))) {
-                return true;
+                return CausaMuerte.COLISION_CUERPO;
             }
         }
 
-        // Colisión con otras serpientes
         for (Snake otra : estado.getSerpientes()) {
             if (serpiente == otra) continue;
 
             if (otra.ocupa(nuevaCabeza)) {
-                // Es una colisión, pero necesitamos ver si es con la cola que está a punto de moverse.
                 Coordenada colaOtra = otra.getCuerpo().getLast();
-
-                // Si la colisión es con la cola Y la serpiente no está creciendo Y la serpiente no es de un solo segmento
-                // (caso borde donde cabeza=cola), entonces no es una colisión real.
                 if (nuevaCabeza.equals(colaOtra) && otra.getSegmentosPorCrecer() == 0 && otra.getCuerpo().size() > 1) {
-                    // No es una colisión fatal, la cola se moverá.
                     continue;
                 }
-                // Si no, es una colisión real con el cuerpo o la cabeza.
-                return true;
+                return CausaMuerte.COLISION_OTRO_JUGADOR;
             }
         }
-        return false;
+        return CausaMuerte.NINGUNA;
     }
 
     private void actualizarTablero(GameState estado) {
@@ -212,7 +229,6 @@ public class GameLogic {
         }
 
         Coordenada nuevaPosicion = celdasVacias.get(random.nextInt(celdasVacias.size()));
-
         int tipoFruta = random.nextInt(100);
         Fruta nuevaFruta;
 

--- a/src/main/java/com/tuempresa/proyecto/demo1/model/CausaMuerte.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/model/CausaMuerte.java
@@ -1,0 +1,31 @@
+package com.tuempresa.proyecto.demo1.model;
+
+/**
+ * Enum que representa las posibles causas de eliminación de una serpiente en el juego.
+ */
+public enum CausaMuerte {
+    /**
+     * La serpiente ha chocado contra una de las paredes del tablero.
+     */
+    COLISION_PARED,
+
+    /**
+     * La serpiente ha chocado contra su propio cuerpo.
+     */
+    COLISION_CUERPO,
+
+    /**
+     * La serpiente ha chocado contra el cuerpo de otra serpiente.
+     */
+    COLISION_OTRO_JUGADOR,
+
+    /**
+     * La serpiente ha chocado de frente contra la cabeza de otra serpiente.
+     */
+    COLISION_CABEZA,
+
+    /**
+     * No se ha producido ninguna colisión.
+     */
+    NINGUNA
+}


### PR DESCRIPTION
Se ha refactorizado la lógica del juego para que, en lugar de un mensaje genérico, se muestre la causa específica de la eliminación de un jugador.

- Se introduce un enum `CausaMuerte` para representar las diferentes causas:
  - `COLISION_PARED`
  - `COLISION_CUERPO`
  - `COLISION_OTRO_JUGADOR`
  - `COLISION_CABEZA`
- Se modifica `GameLogic.java` para detectar y registrar la causa exacta de la muerte, incluyendo colisiones frontales que antes no se gestionaban correctamente.
- El mensaje de log ahora es descriptivo, por ejemplo: "Jugador X eliminado: chocó contra la pared".