### PR TITLE
feat: Add connection dialogs for admin and bot clients

### DIFF
--- a/src/main/java/com/tuempresa/proyecto/demo1/game/Bot.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/game/Bot.java
@@ -34,25 +34,14 @@ public class Bot {
     private BotDifficulty difficulty;
     private final Random random = new Random();
 
-    public static void main(String[] args) {
-        // Lógica para iniciar un bot. Se puede modificar para iniciar múltiples bots.
-        Logger.info("Iniciando un bot...");
-        Bot bot = new Bot();
-        try {
-            bot.start();
-        } catch (IOException | ClassNotFoundException e) {
-            Logger.error("El bot falló al iniciar o se desconectó: " + e.getMessage(), e);
-        }
-    }
-
-    public void start() throws IOException, ClassNotFoundException {
+    public void start(String host, int port) throws IOException, ClassNotFoundException {
         int pick = random.nextInt(BotDifficulty.values().length);
         this.difficulty = BotDifficulty.values()[pick];
         this.botId = "Bot-" + difficulty.name().substring(0, 3) + "-" + java.util.UUID.randomUUID().toString().substring(0, 8);
 
 
-        Logger.info("Bot " + botId + " conectando a " + GameConfig.DEFAULT_HOST + ":" + GameConfig.DEFAULT_PORT);
-        socket = new Socket(GameConfig.DEFAULT_HOST, GameConfig.DEFAULT_PORT);
+        Logger.info("Bot " + botId + " conectando a " + host + ":" + port);
+        socket = new Socket(host, port);
         out = new ObjectOutputStream(socket.getOutputStream());
         in = new ObjectInputStream(socket.getInputStream());
 

--- a/src/main/java/com/tuempresa/proyecto/demo1/game/Game.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/game/Game.java
@@ -3,6 +3,7 @@ package com.tuempresa.proyecto.demo1.game;
 import com.tuempresa.proyecto.demo1.model.Direccion;
 import com.tuempresa.proyecto.demo1.model.GameState;
 import com.tuempresa.proyecto.demo1.model.Snake;
+import com.tuempresa.proyecto.demo1.net.AdminClient;
 import com.tuempresa.proyecto.demo1.net.GameClient;
 import com.tuempresa.proyecto.demo1.net.GameServer;
 import com.tuempresa.proyecto.demo1.net.dto.GameStateSnapshot;
@@ -26,11 +27,11 @@ public class Game {
     private static void createAndShowMainMenu() {
         JFrame frame = new JFrame("Snake Game - Main Menu");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.setSize(300, 200);
+        frame.setSize(300, 250);
         frame.setLocationRelativeTo(null);
 
         JPanel panel = new JPanel();
-        panel.setLayout(new GridLayout(3, 1, 10, 10));
+        panel.setLayout(new GridLayout(5, 1, 10, 10));
         panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
         JButton singlePlayerButton = new JButton("Single Player");
@@ -56,24 +57,79 @@ public class Game {
 
         JButton addBotButton = new JButton("Add Bot");
         addBotButton.addActionListener(e -> {
-            Logger.info("Añadiendo un bot al juego...");
-            new Thread(() -> {
-                try {
-                    Bot bot = new Bot();
-                    bot.start();
-                } catch (Exception ex) {
-                    Logger.error("Falló al iniciar el bot: " + ex.getMessage(), ex);
-                }
-            }).start();
+            frame.dispose();
+            showBotConnectionDialog();
+        });
+
+        JButton adminClientButton = new JButton("Join as Admin");
+        adminClientButton.addActionListener(e -> {
+            frame.dispose();
+            showAdminLoginDialog();
         });
 
         panel.add(singlePlayerButton);
         panel.add(hostGameButton);
         panel.add(joinGameButton);
         panel.add(addBotButton);
+        panel.add(adminClientButton);
 
         frame.add(panel);
         frame.setVisible(true);
+    }
+
+    private static void showAdminLoginDialog() {
+        JTextField hostField = new JTextField(GameConfig.DEFAULT_HOST);
+        JTextField portField = new JTextField(String.valueOf(GameConfig.DEFAULT_PORT));
+
+        JPanel panel = new JPanel(new GridLayout(0, 1));
+        panel.add(new JLabel("Server IP:"));
+        panel.add(hostField);
+        panel.add(new JLabel("Port:"));
+        panel.add(portField);
+
+        int result = JOptionPane.showConfirmDialog(null, panel, "Admin Login",
+                JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+
+        if (result == JOptionPane.OK_OPTION) {
+            String host = hostField.getText();
+            int port = Integer.parseInt(portField.getText());
+
+            Logger.setLogFile(GameConfig.LOG_FILE_ADMIN);
+            Logger.info("Iniciando en modo admin...");
+
+            new Thread(() -> {
+                new AdminClient().start(host, port);
+            }).start();
+        }
+    }
+
+    private static void showBotConnectionDialog() {
+        JTextField hostField = new JTextField(GameConfig.DEFAULT_HOST);
+        JTextField portField = new JTextField(String.valueOf(GameConfig.DEFAULT_PORT));
+
+        JPanel panel = new JPanel(new GridLayout(0, 1));
+        panel.add(new JLabel("Server IP:"));
+        panel.add(hostField);
+        panel.add(new JLabel("Port:"));
+        panel.add(portField);
+
+        int result = JOptionPane.showConfirmDialog(null, panel, "Add Bot",
+                JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+
+        if (result == JOptionPane.OK_OPTION) {
+            String host = hostField.getText();
+            int port = Integer.parseInt(portField.getText());
+
+            Logger.info("Añadiendo un bot al juego...");
+            new Thread(() -> {
+                try {
+                    Bot bot = new Bot();
+                    bot.start(host, port);
+                } catch (Exception ex) {
+                    Logger.error("Falló al iniciar el bot: " + ex.getMessage(), ex);
+                }
+            }).start();
+        }
     }
 
     private static void showJoinGameDialog() {

--- a/src/main/java/com/tuempresa/proyecto/demo1/net/AdminClient.java
+++ b/src/main/java/com/tuempresa/proyecto/demo1/net/AdminClient.java
@@ -29,19 +29,7 @@ public class AdminClient {
     private ObjectInputStream in;
     private ObjectOutputStream out;
 
-    public static void main(String[] args) {
-        Logger.setLogFile(GameConfig.LOG_FILE_ADMIN);
-        SwingUtilities.invokeLater(() -> {
-            try {
-                new AdminClient().start();
-            } catch (IOException e) {
-                Logger.error("Failed to start Admin Client", e);
-                JOptionPane.showMessageDialog(null, "Could not connect to the server: " + e.getMessage(), "Connection Error", JOptionPane.ERROR_MESSAGE);
-            }
-        });
-    }
-
-    public void start() throws IOException {
+    public void start(String host, int port) {
         // Setup GUI
         frame = new JFrame("Game Admin Console");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -76,12 +64,12 @@ public class AdminClient {
         frame.setVisible(true);
 
         // Connect to server and start listening
-        connectAndListen();
+        connectAndListen(host, port);
     }
 
-    private void connectAndListen() {
+    private void connectAndListen(String host, int port) {
         try {
-            socket = new Socket(GameConfig.DEFAULT_HOST, GameConfig.DEFAULT_PORT + 1);
+            socket = new Socket(host, port + 1);
             in = new ObjectInputStream(socket.getInputStream());
             out = new ObjectOutputStream(socket.getOutputStream());
             out.flush();


### PR DESCRIPTION
This commit introduces a new "Join as Admin" button and modifies the "Add Bot" button to provide connection dialogs for both.

- A "Join as Admin" button has been added to the main menu. When clicked, it opens a dialog that prompts the user for the server IP and port to connect to.
- The "Add Bot" button's functionality has been updated. It now opens a similar dialog to get the server details before creating and starting the bot.
- The `AdminClient` and `Bot` classes have been refactored to accept the host and port as parameters in their `start` methods, removing the hardcoded connection details.
- The main menu layout has been adjusted to accommodate the new button.